### PR TITLE
Fix: Update SQLAlchemy version to resolve startup import error

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,7 +1,7 @@
 fastapi>=0.110.0
 starlette>=0.40.0
 uvicorn>=0.27.0
-sqlalchemy==2.0.44
+sqlalchemy>=2.0
 psycopg2-binary>=2.9.10
 prometheus-client==0.23.1
 celery==5.3.4


### PR DESCRIPTION
# Description

## Problem
The application fails to start with an AssertionError during from sqlalchemy.orm import Session.

## Root Cause
SQLAlchemy 2.0.44 is incompatible with Python 3.14's typing changes

## Solution
Resolves AssertionError during 'from sqlalchemy.orm import Session' on Python 3.14
Change to >=2.0 pulls version with fixes
App starts correctly now

## Changes
src/requirements.txt: Updated sqlalchemy==2.0.44 to sqlalchemy>=2.0

## Testing
Docker build succeeds
API starts without import failures
Endpoints respond correctly
This minimal change fixes the compatibility issue, ensuring the app runs reliably.